### PR TITLE
BundlerBase and handling null httpContext and drive letters

### DIFF
--- a/SquishIt.Framework/BundleBase.cs
+++ b/SquishIt.Framework/BundleBase.cs
@@ -89,6 +89,10 @@ namespace SquishIt.Framework
             if (HttpContext.Current == null)
             {
                 file = file.Replace("/", "\\").TrimStart('~').TrimStart('\\');
+                
+                if (file.Length > 2 && file[1] == ':')
+                    return file;
+
                 return @"C:\" + file.Replace("/", "\\");
             }
             return HttpContext.Current.Server.MapPath(file);


### PR DESCRIPTION
I'm running SquishIt in a state where HttpContext is always null.  The code that handles that case previously prepended the passed in resource path with the driver letter C.  I've modified it so that it follows the same logic as Path.IsPathRooted when dealing with drive letters.  This patch allows a fully qualified path to a resource to be used that exists on another drive.
