### PR TITLE
Added method AsEnumerable() to IJavaScriptBundleBuilder

### DIFF
--- a/SquishIt.Framework/Css/CssBundle.cs
+++ b/SquishIt.Framework/Css/CssBundle.cs
@@ -15,7 +15,7 @@ namespace SquishIt.Framework.Css
 {
     internal class CssBundle : BundleBase, ICssBundle, ICssBundleBuilder
     {
-        private static BundleCache bundleCache = new BundleCache();
+        private static BundleCache<string> bundleCache = new BundleCache<string>();
         private static Dictionary<string, string> debugCssFiles = new Dictionary<string, string>();
         private static Dictionary<string, NamedState> namedState = new Dictionary<string, NamedState>();
         private List<string> cssFiles = new List<string>();

--- a/SquishIt.Framework/JavaScript/BundleCache.cs
+++ b/SquishIt.Framework/JavaScript/BundleCache.cs
@@ -5,15 +5,15 @@ using System.Web.Caching;
 
 namespace SquishIt.Framework.JavaScript
 {
-    public class BundleCache
+    public class BundleCache<T>
     {
-        private static Dictionary<string, string> cache = new Dictionary<string, string>();
+        private static Dictionary<string, T> cache = new Dictionary<string, T>();
 
-        public string GetContent(string name)
+        public T GetContent(string name)
         {
             if (HttpContext.Current != null)
             {
-                return (string)HttpContext.Current.Cache["squishit_" + name];
+                return (T)HttpContext.Current.Cache["squishit_" + name];
             }
             return cache[name];
         }
@@ -32,7 +32,7 @@ namespace SquishIt.Framework.JavaScript
             return cache.ContainsKey(key);
         }
 
-        public void AddToCache(string key, string content, List<string> files)
+        public void AddToCache(string key, T content, List<string> files)
         {
             if (HttpContext.Current != null)
             {

--- a/SquishIt.Framework/JavaScript/IJavaScriptBundleBuilder.cs
+++ b/SquishIt.Framework/JavaScript/IJavaScriptBundleBuilder.cs
@@ -1,3 +1,4 @@
+using System.Collections.Generic;
 using SquishIt.Framework.JavaScript.Minifiers;
 
 namespace SquishIt.Framework.JavaScript
@@ -16,5 +17,6 @@ namespace SquishIt.Framework.JavaScript
         IJavaScriptBundleBuilder ForceRelease();
         IJavaScriptBundleBuilder WithAttribute(string name, string value);
         string AsCached(string name, string cssPath);
+        IEnumerable<string> AsEnumerable(string renderTo);
     }
 }

--- a/SquishIt.Framework/JavaScript/RenderedScriptBundle.cs
+++ b/SquishIt.Framework/JavaScript/RenderedScriptBundle.cs
@@ -1,0 +1,8 @@
+namespace SquishIt.Framework.JavaScript
+{
+	internal class RenderedScriptBundle
+	{
+		public string Hash { get; set; }
+		public string[] Files { get; set; }
+	}
+}

--- a/SquishIt.Framework/SquishIt.Framework.csproj
+++ b/SquishIt.Framework/SquishIt.Framework.csproj
@@ -121,6 +121,7 @@
     <Compile Include="JavaScript\Minifiers\MsMinifier.cs" />
     <Compile Include="JavaScript\Minifiers\NullMinifier.cs" />
     <Compile Include="JavaScript\Minifiers\YuiMinifier.cs" />
+    <Compile Include="JavaScript\RenderedScriptBundle.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
     <Compile Include="Renderers\CacheRenderer.cs" />
     <Compile Include="Renderers\FileRenderer.cs" />


### PR DESCRIPTION
Added method AsEnumerable() to IJavaScriptBundleBuilder and refactored JavaScriptBundle to accommodate the new method. This method returns an array of path names to rendered script files instead of html-tags, this is useful for delay loading scripts via javascript.
