### PR TITLE
Allow "Add" method to accept multiple filePaths. 

### DIFF
--- a/SquishIt.Framework/Base/BundleBase.cs
+++ b/SquishIt.Framework/Base/BundleBase.cs
@@ -174,15 +174,15 @@ namespace SquishIt.Framework.Base
             return (T)this;
         }
 
-        public T AddInGroup(string group, params string[] filesPath)
+        public T AddToGroup(string group, params string[] filesPath)
         {
             foreach (var filePath in filesPath)
-                AddInGroup(group, filePath);
+                AddToGroup(group, filePath);
 
             return (T)this;
         }
 
-        public T AddInGroup( string group, string filePath)
+        public T AddToGroup( string group, string filePath)
         {
             AddAsset(new Asset(filePath), group);
             return (T)this;

--- a/SquishIt.Tests/CssBundleTests.cs
+++ b/SquishIt.Tests/CssBundleTests.cs
@@ -66,6 +66,60 @@ namespace SquishIt.Tests
         }
 
         [Test]
+        public void CanAddMultiplePathFiles()
+        {
+            var cssBundle1 = cssBundleFactory
+                .WithDebuggingEnabled(true)
+                .Create();
+
+            var cssBundle2 = cssBundleFactory
+                .WithDebuggingEnabled(true)
+                .Create();
+
+            cssBundle1.Add("/css/first.css", "/css/second.css");
+            cssBundle2.Add("/css/first.css").Add("/css/second.css");
+
+            var cssBundle1Assets = cssBundle1.GroupBundles["default"].Assets;
+            var cssBundle2Assets = cssBundle1.GroupBundles["default"].Assets;
+
+            Assert.AreEqual(cssBundle1Assets.Count, cssBundle2Assets.Count);
+            for (var i = 0; i < cssBundle1Assets.Count; i++)
+            {
+                var assetBundle1 = cssBundle1Assets[i];
+                var assetBundle2 = cssBundle2Assets[i];
+                Assert.AreEqual(assetBundle1.LocalPath, assetBundle2.LocalPath);
+                Assert.AreEqual(assetBundle1.Order, assetBundle2.Order);
+            }
+        }
+
+        [Test]
+        public void CanAddMultiplePathFilesToGroup()
+        {
+            var myGroup = "myGroup";
+            var cssBundle1 = cssBundleFactory
+                .WithDebuggingEnabled(true)
+                .Create();
+
+            var cssBundle2 = cssBundleFactory
+                .WithDebuggingEnabled(true)
+                .Create();
+
+            cssBundle1.AddToGroup(myGroup, "/css/first.css", "/css/second.css");
+            cssBundle2.AddToGroup(myGroup, "/css/first.css").AddToGroup(myGroup, "/css/second.css");
+
+            var cssBundle1Assets = cssBundle1.GroupBundles[myGroup].Assets;
+            var cssBundle2Assets = cssBundle1.GroupBundles[myGroup].Assets;
+
+            Assert.AreEqual(cssBundle1Assets.Count, cssBundle2Assets.Count);
+            for (var i = 0; i < cssBundle1Assets.Count; i++)
+            {
+                var assetBundle1 = cssBundle1Assets[i];
+                var assetBundle2 = cssBundle2Assets[i];
+                Assert.AreEqual(assetBundle1.LocalPath, assetBundle2.LocalPath);
+                Assert.AreEqual(assetBundle1.Order, assetBundle2.Order);
+            }
+        }
+        [Test]
         public void CanBundleCss()
         {
             CSSBundle cssBundle = cssBundleFactory


### PR DESCRIPTION
You can write: Add("file1.js", "file2.js", "file3.js", "file4.js") instead of  Add("file1.js").Add("file2.js").Add("file3.js").Add("file4.js")
This feature allows to write cleaner code.

Signed-off-by: Fernando Rodriguez ferrod20@gmail.com
