### PR TITLE
New feature - Support to subdomains and CDN

### DIFF
--- a/SquishIt.Framework/Base/BundleBase.cs
+++ b/SquishIt.Framework/Base/BundleBase.cs
@@ -15,6 +15,7 @@ namespace SquishIt.Framework.Base
         private static Dictionary<string, string> renderPathCache = new Dictionary<string, string>();
 
         private const string DEFAULT_GROUP = "default";
+        protected string BaseOutputHref = String.Empty;
         protected IFileWriterFactory fileWriterFactory;
         protected IFileReaderFactory fileReaderFactory;
         protected IDebugStatusReader debugStatusReader;
@@ -235,6 +236,12 @@ namespace SquishIt.Framework.Base
             return (T)this;
         }
 
+        public T WithOutputBaseHref(string href)
+        {
+            BaseOutputHref = href;
+            return (T)this;
+        }
+
         public string Render(string renderTo)
         {
             string key = renderTo + GroupBundles.GetHashCode();
@@ -355,6 +362,11 @@ namespace SquishIt.Framework.Base
 
                     string outputFile = FileSystem.ResolveAppRelativePathToFileSystem(renderTo);
                     var renderToPath = ExpandAppRelativePath(renderTo);
+
+                    if (!String.IsNullOrEmpty(BaseOutputHref))
+                    {
+                        renderToPath = String.Concat(BaseOutputHref.TrimEnd('/'), "/", renderToPath.TrimStart('/'));
+                    }
 
                     var localAssetPaths = new List<string>();
                     var remoteAssetPaths = new List<string>();

--- a/SquishIt.Tests/CssBundleTests.cs
+++ b/SquishIt.Tests/CssBundleTests.cs
@@ -119,6 +119,7 @@ namespace SquishIt.Tests
                 Assert.AreEqual(assetBundle1.Order, assetBundle2.Order);
             }
         }
+        
         [Test]
         public void CanBundleCss()
         {
@@ -130,11 +131,33 @@ namespace SquishIt.Tests
             cssBundleFactory.FileReaderFactory.SetContents(css);
 
             string tag = cssBundle
+
                             .Add("/css/first.css")
                             .Add("/css/second.css")
                             .Render("/css/output.css");
 
             Assert.AreEqual("<link rel=\"stylesheet\" type=\"text/css\" href=\"/css/output.css?r=C33D1225DED9D889876CEE87754EE305\" />", tag);
+            Assert.AreEqual(1, cssBundleFactory.FileWriterFactory.Files.Count);
+            Assert.AreEqual("li{margin-bottom:.1em;margin-left:0;margin-top:.1em}th{font-weight:normal;vertical-align:bottom}.FloatRight{float:right}.FloatLeft{float:left}li{margin-bottom:.1em;margin-left:0;margin-top:.1em}th{font-weight:normal;vertical-align:bottom}.FloatRight{float:right}.FloatLeft{float:left}", cssBundleFactory.FileWriterFactory.Files[TestUtilities.PreparePathRelativeToWorkingDirectory(@"C:\css\output.css")]);
+        }
+
+        [Test]
+        public void CanBundleCssSpecifyingOutputLinkPath()
+        {
+            CSSBundle cssBundle = cssBundleFactory
+                .WithHasher(hasher)
+                .WithDebuggingEnabled(false)
+                .Create();
+
+            cssBundleFactory.FileReaderFactory.SetContents(css);
+
+            string tag = cssBundle
+                            .Add("/css/first.css")
+                            .Add("/css/second.css")
+                            .WithOutputBaseHref("http//subdomain.domain.com")
+                            .Render("/css/output.css");
+
+            Assert.AreEqual("<link rel=\"stylesheet\" type=\"text/css\" href=\"http//subdomain.domain.com/css/output.css?r=C33D1225DED9D889876CEE87754EE305\" />", tag);
             Assert.AreEqual(1, cssBundleFactory.FileWriterFactory.Files.Count);
             Assert.AreEqual("li{margin-bottom:.1em;margin-left:0;margin-top:.1em}th{font-weight:normal;vertical-align:bottom}.FloatRight{float:right}.FloatLeft{float:left}li{margin-bottom:.1em;margin-left:0;margin-top:.1em}th{font-weight:normal;vertical-align:bottom}.FloatRight{float:right}.FloatLeft{float:left}", cssBundleFactory.FileWriterFactory.Files[TestUtilities.PreparePathRelativeToWorkingDirectory(@"C:\css\output.css")]);
         }


### PR DESCRIPTION
Added support to specify the final URL used in Href attribute of the link element in case you want to use a subdomain or a CDN.

It should be used as follow:

Bundle.Css()
            .Add("~/CssFile1")
            .Add("~/CssFile2")
            .WithOutputBaseHref("http://static.mydomain.com")
            .Render("/combined_#.css") 

This way the file will be created physically like it would but the href attribute in the output link tag would be: http://static.mydomain.com/combined_#.css
