### PR TITLE
when squishing the following css Squishit threw an exception (because of regex metacharacters in the url)

### DIFF
--- a/SquishIt.Framework/Css/CssPathRewriter.cs
+++ b/SquishIt.Framework/Css/CssPathRewriter.cs
@@ -54,7 +54,7 @@ namespace SquishIt.Framework.Css
 
         private static string ReplaceRelativePathsIn(string css, string oldPath, string newPath)
         {
-            var regex = new Regex(@"url\([""']{0,1}" + oldPath + @"[""']{0,1}\)", RegexOptions.IgnoreCase);
+            var regex = new Regex(@"url\([""']{0,1}" + Regex.Escape(oldPath) + @"[""']{0,1}\)", RegexOptions.IgnoreCase);
 
             return regex.Replace(css, match =>
             {

--- a/SquishIt.Tests/CssPathRewriterTests.cs
+++ b/SquishIt.Tests/CssPathRewriterTests.cs
@@ -315,6 +315,41 @@ namespace SquishIt.Tests
         }
 
         [Test]
+        public void DontThrowIfPathContainsRegexMetacharacters()
+        {
+            ICssAssetsFileHasher cssAssetsFileHasher = null;
+            string css =
+                @"
+                                                        .header {
+                                                                background-image: URL(""*../img/something.jpg"");
+                                                                background-image: url(c:\documents\usr8\local\temp\1\d1b73b93-5ff0-11de-9339-0017317c60aa); 
+                                                        }
+
+                                                        .footer {
+                                                                background-image: uRL(""..c:\1\2\somethingelse.jpg"");
+                                                        }
+                                                    ";
+            string sourceFile = TestUtilities.PreparePath(@"C:\somepath\somesubpath\myfile.css");
+            string targetFile = TestUtilities.PreparePath(@"C:\somepath\output.css");
+            string result = CSSPathRewriter.RewriteCssPaths(targetFile, sourceFile, css, cssAssetsFileHasher);
+
+            //concrete result doesn't matter here (since input isn't valid)
+            //the only important thing is that it shouldn't throw exceptions
+            string expected =
+                @"
+                                                        .header {
+                                                                background-image: URL(""somesubpath/*/img/something.jpg"");
+                                                                background-image: url(../documents/usr8/local/temp/1/d1b73b93-5ff0-11de-9339-0017317c60aa); 
+                                                        }
+
+                                                        .footer {
+                                                                background-image: uRL(""somesubpath/..c:/1/2/somethingelse.jpg"");
+                                                        }
+                                                    ";
+            Assert.AreEqual(expected, result);
+        }
+
+        [Test]
         public void WontRewriteAbsolutePaths()
         {
             ICssAssetsFileHasher cssAssetsFileHasher = null;


### PR DESCRIPTION
.header {
    background-image: url(c:\documents and settings\usr8\local settings\temp\1\d1b73b93-5ff0-11de-9339-0017317c60aa);
}
