### PR TITLE
BundleCache - Filter CacheDependency files

### DIFF
--- a/SquishIt.Framework/BundleCache.cs
+++ b/SquishIt.Framework/BundleCache.cs
@@ -1,5 +1,7 @@
 using System;
 using System.Collections.Generic;
+using System.IO;
+using System.Linq;
 using System.Web;
 using System.Web.Caching;
 
@@ -37,8 +39,14 @@ namespace SquishIt.Framework
 
         public void Add(string key, string content, List<string> files)
         {
-            CacheKeys.Add(KEY_PREFIX + key);
-            HttpRuntime.Cache.Add(KEY_PREFIX + key, content, new CacheDependency(files.ToArray()),
+            var cacheKey = KEY_PREFIX + key;
+            CacheKeys.Add(cacheKey);
+
+            var physicalFiles = files.Where(File.Exists).ToArray();
+            var cacheDependency = physicalFiles.Length > 0
+                ? new CacheDependency(physicalFiles)
+                : null;
+            HttpRuntime.Cache.Add(cacheKey, content, cacheDependency,
                                             Cache.NoAbsoluteExpiration, 
                                             new TimeSpan(365, 0, 0, 0),
                                             CacheItemPriority.NotRemovable,


### PR DESCRIPTION
This is a a small bug fix for BundleCache, to filter files that is monitored for changes by a CacheDependency, so that only physical files that can be monitored is included in the file list. My use case was that a script bundle included a "non-physical" file exposed by a virtual path provider. It is otherwise fully supported by Squishit, but it threw an exception when the CacheDependency was created.

This change is backward compatible and shouldn't negatively affect any existing code. All tests pass, of course. Please tell me if I need to improve something!
