### PR TITLE
Rewrite of the mutex-based serialization code

### DIFF
--- a/SquishIt.Framework/Base/BundleBase.cs
+++ b/SquishIt.Framework/Base/BundleBase.cs
@@ -1,10 +1,7 @@
 using System;
 using System.Collections.Generic;
 using System.Linq;
-using System.Security.AccessControl;
 using System.Text;
-using System.Text.RegularExpressions;
-using System.Threading;
 using System.Web;
 using SquishIt.Framework.Minifiers;
 using SquishIt.Framework.Resolvers;
@@ -38,6 +35,13 @@ namespace SquishIt.Framework.Base
                 return minifier ?? DefaultMinifier;
             }
             set { minifier = value; }
+        }
+
+        private IFilePathMutexProvider mutexProvider;
+        protected IFilePathMutexProvider MutexProvider
+        {
+            get { return mutexProvider ?? (mutexProvider = FilePathMutexProvider.Instance); }
+            set { mutexProvider = value; }
         }
 
         protected string HashKeyName { get; set; }
@@ -389,39 +393,12 @@ namespace SquishIt.Framework.Base
             return content;
         }
 
-        private const string renderMutexId = @"Global\C9CA8ED9-9354-4047-8601-5CC0602FC505";
-        private static Mutex renderMutex = CreateSharableRenderReleaseMutex();
-
-        private static Mutex CreateSharableRenderReleaseMutex()
-        {
-            // Creates a mutex sharable by more than one process
-            Mutex mutex;
-            try
-            {
-                // Try opening an existing mutex
-                mutex = Mutex.OpenExisting(renderMutexId, MutexRights.FullControl);
-            }
-            catch (WaitHandleCannotBeOpenedException)
-            {
-                mutex = null; // An expected case, the mutex needs to be created
-            }
-
-            if (mutex == null)
-            {
-                bool createdNew; // Uninteresting in this case, but required by the constructor
-                var mutexSecurity = new MutexSecurity();
-                mutexSecurity.AddAccessRule(new MutexAccessRule("Everyone", MutexRights.FullControl, AccessControlType.Allow));
-                mutex = new Mutex(false, renderMutexId, out createdNew, mutexSecurity);
-            }
-            
-            return mutex;
-        }
-
         private string RenderRelease(string key, string renderTo, IRenderer renderer)
         {
             string content;
             if (!bundleCache.TryGetValue(key, out content))
             {
+                var renderMutex = MutexProvider.GetMutexForPath(renderTo);
                 renderMutex.WaitOne();
                 try
                 {

--- a/SquishIt.Framework/SquishIt.Framework.csproj
+++ b/SquishIt.Framework/SquishIt.Framework.csproj
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="utf-8"?>
+﻿<?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="4.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <PropertyGroup>
     <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
@@ -138,9 +138,11 @@
     <Compile Include="Files\IFileReaderFactory.cs" />
     <Compile Include="Files\IFileWriter.cs" />
     <Compile Include="Files\IFileWriterFactory.cs" />
+    <Compile Include="Utilities\IFilePathMutexProvider.cs" />
     <Compile Include="Utilities\IHasher.cs" />
     <Compile Include="Utilities\NamedState.cs" />
     <Compile Include="FileSystem.cs" />
+    <Compile Include="Utilities\FilePathMutexProvider.cs" />
   </ItemGroup>
   <ItemGroup>
     <Content Include="closure-compiler\compiler.jar">

--- a/SquishIt.Framework/Utilities/FilePathMutexProvider.cs
+++ b/SquishIt.Framework/Utilities/FilePathMutexProvider.cs
@@ -1,0 +1,94 @@
+﻿using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Security.AccessControl;
+using System.Threading;
+using SquishIt.Framework.Files;
+
+namespace SquishIt.Framework.Utilities
+{
+	public class FilePathMutexProvider : IFilePathMutexProvider
+	{
+		private const string NullPathSurrogate = "<NULL>";
+
+		private static readonly IFilePathMutexProvider instance = new FilePathMutexProvider();
+		private static readonly object createMutexLock = new object();
+
+		private readonly Dictionary<string, Mutex> pathMutexes =
+			new Dictionary<string, Mutex>(StringComparer.Ordinal);
+		private readonly IHasher hasher;
+
+		public static IFilePathMutexProvider Instance
+		{
+			get { return instance; }
+		}
+
+		public FilePathMutexProvider()
+			: this(new Hasher(new RetryableFileOpener()))
+		{
+		}
+
+		public FilePathMutexProvider(IHasher hasher)
+		{
+			this.hasher = hasher;
+		}
+
+		public Mutex GetMutexForPath(string path)
+		{
+			Mutex result;
+
+			string normalizedPath = GetNormalizedPath(path);
+			if (pathMutexes.TryGetValue(normalizedPath, out result))
+			{
+				return result;
+			}
+
+			lock (createMutexLock)
+			{
+				if (pathMutexes.TryGetValue(normalizedPath, out result))
+				{
+					return result;
+				}
+
+				result = CreateSharableMutexForPath(normalizedPath);
+				pathMutexes[normalizedPath] = result;
+			}
+
+			return result;
+		}
+
+		private static string GetNormalizedPath(string path)
+		{
+			if (String.IsNullOrEmpty(path))
+			{
+				return NullPathSurrogate;
+			}
+
+			// Normalize the path
+			var fileSystemPath = FileSystem.ResolveAppRelativePathToFileSystem(path);
+			// The path is lower cased to avoid different hashes. Even on a case sensitive
+			// file system this probably is okay, since it's a web application
+			return Path.GetFullPath(fileSystemPath)
+				.ToLowerInvariant();
+		}
+
+		private Mutex CreateSharableMutexForPath(string normalizedPath)
+		{
+			// The path is transformed to a hash value to avoid getting an invalid Mutex name.
+			var mutexName = @"Global\SquishitPath" + hasher.GetHash(normalizedPath);
+			return CreateSharableMutex(mutexName);
+		}
+
+		private static Mutex CreateSharableMutex(string name)
+		{
+			// Creates a mutex sharable by more than one process
+			var mutexSecurity = new MutexSecurity();
+			mutexSecurity.AddAccessRule(new MutexAccessRule("Everyone", MutexRights.FullControl, AccessControlType.Allow));
+
+			// The constructor will either create new mutex or open
+			// an existing one, in a thread-safe manner
+			bool createdNew;
+			return new Mutex(false, name, out createdNew, mutexSecurity);
+		}
+	}
+}

--- a/SquishIt.Framework/Utilities/IFilePathMutexProvider.cs
+++ b/SquishIt.Framework/Utilities/IFilePathMutexProvider.cs
@@ -1,0 +1,9 @@
+using System.Threading;
+
+namespace SquishIt.Framework.Utilities
+{
+	public interface IFilePathMutexProvider
+	{
+		Mutex GetMutexForPath(string path);
+	}
+}


### PR DESCRIPTION
I rewrote the mutex-based serialization code so that a mutex is created for each rendered path, which at least theoretically avoids a bottleneck. It should now also be fully thread-safe.

To avoid opening many handles to the mutexes, I used a simple singleton pattern for the implementation class. It can still be replaced for an instance of BundleBase, in case a test requires it.
