### PR TITLE
Nested .less imports not being included as CacheDependencies

### DIFF
--- a/SquishIt.Framework/Base/BundleBase.cs
+++ b/SquishIt.Framework/Base/BundleBase.cs
@@ -48,7 +48,7 @@ namespace SquishIt.Framework.Base
 
         protected string HashKeyName { get; set; }
         private bool ShouldRenderOnlyIfOutputFileIsMissing { get; set; }
-        protected List<string> DependentFiles = new List<string>();
+        internal List<string> DependentFiles = new List<string>();
         internal Dictionary<string, GroupBundle> GroupBundles = new Dictionary<string, GroupBundle>
         {
             { DEFAULT_GROUP, new GroupBundle() }

--- a/SquishIt.Framework/Css/CssBundle.cs
+++ b/SquishIt.Framework/Css/CssBundle.cs
@@ -73,11 +73,22 @@ namespace SquishIt.Framework.Css
             {
                 try
                 {
-                    currentDirectoryWrapper.SetCurrentDirectory(Path.GetDirectoryName(file));
+                    var dir = Path.GetDirectoryName(file);
+                    currentDirectoryWrapper.SetCurrentDirectory(dir);
                     var content = ReadFile(file);
                     var engineFactory = new EngineFactory();
                     var engine = engineFactory.GetEngine();
-                    return engine.TransformToCss(content, file);
+                    var css = engine.TransformToCss(content, file);
+
+                    var appPath = FileSystem.ResolveFileSystemPathToAppRelative(dir);
+                    var importPaths = engine.GetImports();
+                    foreach (var importPath in importPaths)
+                    {
+                        var import = FileSystem.ResolveAppRelativePathToFileSystem(Path.Combine(appPath, importPath));
+                        DependentFiles.Add(import);
+                    }
+
+                    return css;
                 }
                 finally
                 {

--- a/SquishIt.Tests/CssBundleTests.cs
+++ b/SquishIt.Tests/CssBundleTests.cs
@@ -8,6 +8,7 @@ using SquishIt.Framework.Utilities;
 using SquishIt.Tests.Helpers;
 using SquishIt.Tests.Stubs;
 using SquishIt.Framework.Tests.Mocks;
+using SquishIt.Framework;
 
 namespace SquishIt.Tests
 {
@@ -274,6 +275,33 @@ namespace SquishIt.Tests
             Assert.AreEqual("#header{color:#4d926f;background-image:url(image/mygif.gif)}", contents);
         }
 
+        [Test]
+        public void CanBundleCssWithNestedLess()
+        {
+            string importCss =
+                        @"
+                        @import 'other.less';
+                        #header {
+                            color: #4D926F;
+                        }";
+
+            CSSBundle cssBundle = cssBundleFactory
+                .WithDebuggingEnabled(false)
+                .WithContents(importCss)
+                .Create();
+
+            TestUtilities.CreateFile("other.less", "#footer{color:#ffffff}");
+
+            cssBundle
+                .Add("~/css/test.less")
+                .Render("~/css/output_test.css");
+
+            TestUtilities.DeleteFile("other.less");
+
+            Assert.AreEqual("#footer{color:#fff}#header{color:#4d926f}", cssBundleFactory.FileWriterFactory.Files[TestUtilities.PrepareRelativePath(@"css\output_test.css")]);
+            Assert.Contains(FileSystem.ResolveAppRelativePathToFileSystem("css/other.less"), cssBundle.DependentFiles);
+        }
+        
         [Test]
         public void CanBundleCssWithLessWithLessDotCssFileExtension()
         {

--- a/SquishIt.Tests/Helpers/TestUtilities.cs
+++ b/SquishIt.Tests/Helpers/TestUtilities.cs
@@ -43,6 +43,11 @@ namespace SquishIt.Tests.Helpers
             }
             return path;
         }
+
+        public static void DeleteFile(string path)
+        {
+            File.Delete(path);
+        }
     }
 }
 


### PR DESCRIPTION
SquishIt will currently process @import directives within your CSS if you use CSSBundle.ProcessImports(). However, this only handles .css imports - .less @import directives are ignored because by the time the ProcessImport logic fires, dotless has already parsed them and removed them from the CSS it outputs, meaning they don't get picked up by the IMPORT_PATTERN regexp check.

Because of this, .less imports never get treated as CacheDependencies, so any changes to them do not trigger a recompile of the parent CSS automatically.

This pull request adds all .less imports parsed by dotless as CacheDependencies. Any .css imports are left behind by dotless and will therefore continue to be handled by the existing logic.

The logic isn't wrapped up behind the ProcessImports option as there's no point - it's not like you can choose to leave a .less @import directive in your raw output as dotless won't let that happen anyway.
