### PR TITLE
BaseOutputHrefCachingFix

### DIFF
--- a/SquishIt.Framework/Base/BundleBase.cs
+++ b/SquishIt.Framework/Base/BundleBase.cs
@@ -272,6 +272,10 @@ namespace SquishIt.Framework.Base
         private string Render(string renderTo, string key, IRenderer renderer)
         {
             key = CachePrefix + key;
+            if (!String.IsNullOrEmpty(BaseOutputHref))
+            {
+                key = BaseOutputHref + key;
+            }
 
             if (debugStatusReader.IsDebuggingEnabled())
             {

--- a/SquishIt.Tests/CssBundleTests.cs
+++ b/SquishIt.Tests/CssBundleTests.cs
@@ -137,6 +137,42 @@ namespace SquishIt.Tests
         }
 
         [Test]
+        public void CanBundleCssVaryingOutputBaseHrefRendersIndependantUrl()
+        {
+            //Verify that depending on basehref, we get independantly cached and returned URLs
+            CSSBundle cssBundle = cssBundleFactory
+                .WithHasher(hasher)
+                .WithDebuggingEnabled(false)
+                .Create();
+
+            cssBundleFactory.FileReaderFactory.SetContents(css);
+
+            string tag = cssBundle
+                            .Add("/css/first.css")
+                            .Add("/css/second.css")
+                            .WithOutputBaseHref("http//subdomain.domain.com")
+                            .Render("/css/output.css");
+
+            CSSBundle cssBundleNoBaseHref = cssBundleFactory
+                .WithHasher(hasher)
+                .WithDebuggingEnabled(false)
+                .Create();
+
+            cssBundleFactory.FileReaderFactory.SetContents(css);
+
+            string tagNoBaseHref = cssBundleNoBaseHref
+                            .Add("/css/first.css")
+                            .Add("/css/second.css")
+                            .Render("/css/output.css");
+
+           Assert.AreEqual("<link rel=\"stylesheet\" type=\"text/css\" href=\"http//subdomain.domain.com/css/output.css?r=C33D1225DED9D889876CEE87754EE305\" />", tag);
+           Assert.AreEqual("<link rel=\"stylesheet\" type=\"text/css\" href=\"/css/output.css?r=C33D1225DED9D889876CEE87754EE305\" />", tagNoBaseHref);
+           Console.WriteLine("WithBaseHref:" + tag);
+           Console.WriteLine("NoBaseHref:" + tagNoBaseHref);
+        }
+
+
+        [Test]
         public void CanBundleCssWithQueryStringParameter()
         {
             CSSBundle cssBundle = cssBundleFactory


### PR DESCRIPTION
Varying BaseOutputHref - used for adding CDN support - does not generate an independent URL in the cache, since the cache key is only concerned with file attributes and contents.  At present, the first call to the Render method will be cached for a particular set of files and whatever value we have for BaseOutputHref is inserted into the cache content.  If BaseOutputHref changes, subsequent calls will not honour the new value of BaseOutputHref since they will simply return the older, incorrect cache content (retrieved based on the key).

To fix this, I've added the BaseOutputHref to the cache key, meaning it should generate independent Urls for any differing value of this parameter.

I saw this issue with a CDN that does not support SSL.  Therefore I want all SSL traffic to reference the origin (relative path). I have a method to determine if the HTTP context is currently SSL, and then depending on this, vary the value of BaseOutputHref accordingly so that HTTP pages are served JS and CSS from the CDN.

I've added a test method to the CSS builder section in the test assembly to determine whether the URLs are indeed varied correctly.  I did not add a test to the equivalent JS test class, since we are testing the functionality inside the BundleBase class, not the specific Js/Css sub-classes.

Best
Adam
