### PR TITLE
Basic Custom Bundler solution for #157

### DIFF
--- a/SquishIt.Framework/Bundle.cs
+++ b/SquishIt.Framework/Bundle.cs
@@ -7,8 +7,14 @@ namespace SquishIt.Framework
     {
         public static JavaScriptBundle JavaScript()
         {
-            return new JavaScriptBundle();
+            return JavaScript<JavaScriptBundle>();
         }
+
+        public static JavaScriptBundle JavaScript<TBundle>()
+            where TBundle : JavaScriptBundle, new()
+        {
+            return new TBundle();
+        }        
 
         public static JavaScriptBundle JavaScript(Utilities.IDebugStatusReader debugStatusReader)
         {

--- a/SquishIt.Tests/JavaScriptBundleTests.cs
+++ b/SquishIt.Tests/JavaScriptBundleTests.cs
@@ -659,5 +659,57 @@ namespace SquishIt.Tests
             var minifiedScript = "function product(n,t){return n*t}function sum(n,t){return n+t}function sub(n,t){return n-t}function div(n,t){return n/t}";
             Assert.AreEqual(minifiedScript, writerFactory.Files[TestUtilities.PrepareRelativePath(@"output.js")]);
         }
+
+        [Test]
+        public void CanBundleJavaScriptWithCustomBundler()
+        {
+            var js2Format = "{0}{1}";
+
+            var subtract = "function sub(a,b){return a-b}";
+            var divide = "function div(a,b){return a/b}";
+
+            var writerFactory = new StubFileWriterFactory();
+
+            var tag = new JavaScriptBundleFactory()
+                    .WithDebuggingEnabled(false)
+                    .WithFileWriterFactory(writerFactory)
+                    .WithHasher(new StubHasher("hashy"))
+                    .Create<StubCustomJavaScriptBundler>(details => new StubCustomJavaScriptBundler(details.DebugStatusReader, details.FileWriterFactory, details.FileReaderFactory, details.CurrentDirectoryWrapper, details.Hasher, details.BundleCache))
+                    .AddString(javaScript)
+                    .AddString(js2Format, subtract, divide)
+                    .Render("~/output.js");
+
+            var expectedTag = "<script type=\"text/javascript\" src=\"output.js?r=hashy\"></script>";
+            Assert.AreEqual(expectedTag, TestUtilities.NormalizeLineEndings(tag));
+
+            var minifiedScript = "function product(n,t){return n*t}function sum(n,t){return n+t}function sub(n,t){return n-t}function div(n,t){return n/t}";
+            Assert.AreEqual(minifiedScript, writerFactory.Files[TestUtilities.PrepareRelativePath(@"output.js")]);
+        }
+
+        [Test]
+        public void CanBundleJavaScriptWithoutHashWithCustomBundler()
+        {
+            var js2Format = "{0}{1}";
+
+            var subtract = "function sub(a,b){return a-b}";
+            var divide = "function div(a,b){return a/b}";
+
+            var writerFactory = new StubFileWriterFactory();
+
+            var tag = new JavaScriptBundleFactory()
+                    .WithDebuggingEnabled(false)
+                    .WithFileWriterFactory(writerFactory)
+                    .WithHasher(new StubHasher("hashy"))
+                    .Create<StubCustomNoHashJavaScriptBundler>(details => new StubCustomNoHashJavaScriptBundler(details.DebugStatusReader, details.FileWriterFactory, details.FileReaderFactory, details.CurrentDirectoryWrapper, details.Hasher, details.BundleCache))
+                    .AddString(javaScript)
+                    .AddString(js2Format, subtract, divide)
+                    .Render("~/output.js");
+
+            var expectedTag = "<script type=\"text/javascript\" src=\"output.js\"></script>";
+            Assert.AreEqual(expectedTag, TestUtilities.NormalizeLineEndings(tag));
+
+            var minifiedScript = "function product(n,t){return n*t}function sum(n,t){return n+t}function sub(n,t){return n-t}function div(n,t){return n/t}";
+            Assert.AreEqual(minifiedScript, writerFactory.Files[TestUtilities.PrepareRelativePath(@"output.js")]);
+        }
     }
 }

--- a/SquishIt.Tests/SquishIt.Tests.csproj
+++ b/SquishIt.Tests/SquishIt.Tests.csproj
@@ -78,6 +78,7 @@
     <Compile Include="JavaScriptBundleTests.cs" />
     <Compile Include="JavaScriptMinifierTests.cs" />
     <Compile Include="MultipleWorkerProcessesTests.cs" />
+    <Compile Include="Stubs\StubCustomJavaScriptBundler.cs" />
     <Compile Include="Stubs\StubBundleCache.cs" />
     <Compile Include="Stubs\StubCurrentDirectoryWrapper.cs" />
     <Compile Include="Stubs\StubDebugStatusReader.cs" />

--- a/SquishIt.Tests/Stubs/StubCustomJavaScriptBundler.cs
+++ b/SquishIt.Tests/Stubs/StubCustomJavaScriptBundler.cs
@@ -1,0 +1,35 @@
+﻿using System.Collections.Generic;
+using SquishIt.Framework;
+using SquishIt.Framework.Files;
+using SquishIt.Framework.JavaScript;
+using SquishIt.Framework.Utilities;
+
+namespace SquishIt.Tests.Stubs
+{
+    public class StubCustomJavaScriptBundler : JavaScriptBundle
+    {
+        public StubCustomJavaScriptBundler(IDebugStatusReader debugStatusReader, IFileWriterFactory fileWriterFactory, IFileReaderFactory fileReaderFactory, ICurrentDirectoryWrapper currentDirectoryWrapper, IHasher hasher, IBundleCache bundleCache)
+            : base(debugStatusReader, fileWriterFactory, fileReaderFactory, currentDirectoryWrapper, hasher, bundleCache)
+        { }
+
+        protected override string BeforeMinify(string outputFile, List<string> files, IEnumerable<string> arbitraryContent)
+        {
+            return base.BeforeMinify(outputFile, files, arbitraryContent);
+        }
+    }
+
+    public class StubCustomNoHashJavaScriptBundler : JavaScriptBundle
+    {
+        public StubCustomNoHashJavaScriptBundler(IDebugStatusReader debugStatusReader, IFileWriterFactory fileWriterFactory, IFileReaderFactory fileReaderFactory, ICurrentDirectoryWrapper currentDirectoryWrapper, IHasher hasher, IBundleCache bundleCache)
+            : base(debugStatusReader, fileWriterFactory, fileReaderFactory, currentDirectoryWrapper, hasher, bundleCache)
+        { }
+
+        protected override string BeforeMinify(string outputFile, List<string> files, IEnumerable<string> arbitraryContent)
+        {
+            // Set the hash key to empty to keep it from being appended in Render.
+            HashKeyNamed(string.Empty);
+
+            return base.BeforeMinify(outputFile, files, arbitraryContent);
+        }
+    }
+}

--- a/SquishItAspNetTest/Bundlers/NoHashJavaScriptBundler.cs
+++ b/SquishItAspNetTest/Bundlers/NoHashJavaScriptBundler.cs
@@ -1,0 +1,20 @@
+﻿using System.Collections.Generic;
+using SquishIt.Framework.JavaScript;
+
+namespace SquishItAspNetTest.Bundlers
+{
+    public class NoHashJavaScriptBundle : JavaScriptBundle
+    {
+        public NoHashJavaScriptBundle()
+            : base()
+        { }
+
+        protected override string BeforeMinify(string outputFile, List<string> files, IEnumerable<string> arbitraryContent)
+        {
+            // Set the hash key to empty so the render doesn't append it.
+            HashKeyNamed(string.Empty);
+
+            return base.BeforeMinify(outputFile, files, arbitraryContent);
+        }
+    }
+}

--- a/SquishItAspNetTest/Global.asax.cs
+++ b/SquishItAspNetTest/Global.asax.cs
@@ -5,6 +5,7 @@ using System.Web;
 using System.Web.Security;
 using System.Web.SessionState;
 using SquishIt.Framework;
+using SquishItAspNetTest.Bundlers;
 
 namespace SquishItAspNetTest
 {
@@ -17,6 +18,13 @@ namespace SquishItAspNetTest
                 .ForceRelease()
                 .Add("~/js/alert.js")
                 .AsNamed("test", "~/js/output_#.js");
+
+            // Example using no hash key.
+            //Bundle.JavaScript<NoHashJavaScriptBundle>()
+            //    .ForceRelease()
+            //    .Add("~/js/alert.js")
+            //    .AsNamed("test", "~/js/output-DontHashMeBro.js");
+            
         }
 
         protected void Session_Start(object sender, EventArgs e)

--- a/SquishItAspNetTest/SquishItAspNetTest.csproj
+++ b/SquishItAspNetTest/SquishItAspNetTest.csproj
@@ -90,6 +90,7 @@
     </Content>
   </ItemGroup>
   <ItemGroup>
+    <Compile Include="Bundlers\NoHashJavaScriptBundler.cs" />
     <Compile Include="Constants.cs" />
     <Compile Include="Global.asax.cs">
       <DependentUpon>Global.asax</DependentUpon>


### PR DESCRIPTION
I took a look and think this is a basic solution for extending the existing Bundle() method to allow some custom bundlers.  I'm not happy about having to know about the internal workings of the JavaScriptBundle Render method in order to stop the hashkey from appending, but I think it's a good stopgap solution that doesn't require you to change much other code.

I added some generic methods for creating the JavaScriptBundle from the Factory and refactored the existing Create() to use them.  I made sure the unit tests still passed and added a couple that should give a basic testing of the new custom bundle functionality.  There weren't any BundleTests so I didn't bother to create them, but I did add an example in the SquishItAspNetTest Global.asax.cs below the existing Bundle() (I commented it out so there wouldn't be any surprises).
