### PR TITLE
Support for AddDirectory(string path, isRecursive = true) to BundleBase

### DIFF
--- a/SquishIt.Framework/Base/Asset.cs
+++ b/SquishIt.Framework/Base/Asset.cs
@@ -9,6 +9,7 @@ namespace SquishIt.Framework.Base
         internal int Order { get; set; }
         internal bool IsEmbeddedResource { get; set; }
         internal bool DownloadRemote { get; set; }
+        internal bool IsRecursive { get; set; }
 
         internal bool IsLocal
         {
@@ -34,12 +35,13 @@ namespace SquishIt.Framework.Base
         {
         }
 
-        internal Asset(string localPath, string remotePath = null, int order = 0, bool isEmbeddedResource = false)
+        internal Asset(string localPath, string remotePath = null, int order = 0, bool isEmbeddedResource = false, bool isRecursive = true)
         {
             LocalPath = localPath;
             RemotePath = remotePath;
             Order = order;
             IsEmbeddedResource = isEmbeddedResource;
+            IsRecursive = isRecursive;
         }
     }
 }

--- a/SquishIt.Framework/Base/BundleBase.cs
+++ b/SquishIt.Framework/Base/BundleBase.cs
@@ -80,7 +80,7 @@ namespace SquishIt.Framework.Base
             {
                 if (debugStatusReader.IsDebuggingEnabled())
                 {
-                    return GetFileSystemPath(asset.LocalPath);
+                    return GetFileSystemPath(asset.LocalPath, asset.IsRecursive);
                 }
 
                 if (asset.IsRemoteDownload)
@@ -89,7 +89,7 @@ namespace SquishIt.Framework.Base
                 }
                 else
                 {
-                    return GetFileSystemPath(asset.LocalPath);
+                    return GetFileSystemPath(asset.LocalPath, asset.IsRecursive);
                 }
             }
             else
@@ -108,20 +108,20 @@ namespace SquishIt.Framework.Base
             return inputFiles;
         }
 
-        private Input GetFileSystemPath(string localPath)
+        private Input GetFileSystemPath(string localPath, bool isRecursive = true)
         {
             string mappedPath = FileSystem.ResolveAppRelativePathToFileSystem(localPath);
-            return new Input(mappedPath, ResolverFactory.Get<FileSystemResolver>());
+            return new Input(mappedPath, isRecursive, ResolverFactory.Get<FileSystemResolver>());
         }
 
         private Input GetHttpPath(string remotePath)
         {
-            return new Input(remotePath, ResolverFactory.Get<HttpResolver>());
+            return new Input(remotePath, false, ResolverFactory.Get<HttpResolver>());
         }
 
         private Input GetEmbeddedResourcePath(string resourcePath)
         {
-            return new Input(resourcePath, ResolverFactory.Get<EmbeddedResourceResolver>());
+            return new Input(resourcePath, false, ResolverFactory.Get<EmbeddedResourceResolver>());
         }
 
         private string ExpandAppRelativePath(string file)
@@ -196,6 +196,12 @@ namespace SquishIt.Framework.Base
         {
             AddAsset(new Asset(fileOrFolderPath));
             return (T)this;
+        }
+
+        public T AddDirectory(string folderPath, bool recursive = true)
+        {
+          AddAsset(new Asset(folderPath, isRecursive: recursive));
+          return (T)this;
         }
 
         public T AddString(string content)

--- a/SquishIt.Framework/Files/Input.cs
+++ b/SquishIt.Framework/Files/Input.cs
@@ -6,10 +6,12 @@ namespace SquishIt.Framework.Files
     {
         public string Path { get; private set; }
         public Resolvers.IResolver Resolver { get; private set; }
+        public bool IsRecursive { get; private set; }
 	
-        public Input(string filePath, Resolvers.IResolver resolver)
+        public Input(string filePath, bool recursive, Resolvers.IResolver resolver)
         {
             Path = filePath;
+            IsRecursive = recursive;
             Resolver = resolver;
         }
 
@@ -21,7 +23,7 @@ namespace SquishIt.Framework.Files
         {
             if (IsDirectory) 
             {
-                return Resolver.TryResolveFolder(Path, allowedExtensions);
+                return Resolver.TryResolveFolder(Path, IsRecursive, allowedExtensions);
             }
             else 
             {

--- a/SquishIt.Framework/Resolvers/EmbeddedResourceResolver.cs
+++ b/SquishIt.Framework/Resolvers/EmbeddedResourceResolver.cs
@@ -32,7 +32,8 @@ namespace SquishIt.Framework.Resolvers
             }
         }
 
-        public IEnumerable<string> TryResolveFolder(string path, IEnumerable<string> allowedExtensions) {
+        public IEnumerable<string> TryResolveFolder(string path, bool recursive, IEnumerable<string> allowedExtensions)
+        {
             throw new NotImplementedException("Adding entire directories only supported by FileSystemResolver.");
         }
 

--- a/SquishIt.Framework/Resolvers/FileSystemResolver.cs
+++ b/SquishIt.Framework/Resolvers/FileSystemResolver.cs
@@ -17,11 +17,11 @@ namespace SquishIt.Framework.Resolvers
             return Directory.Exists(path);
         }
 
-        public IEnumerable<string> TryResolveFolder(string path, IEnumerable<string> allowedFileExtensions)
+        public IEnumerable<string> TryResolveFolder(string path, bool recursive, IEnumerable<string> allowedFileExtensions)
         {
             if (IsDirectory(path)) 
             {
-                var files = Directory.GetFiles(path, "*.*", SearchOption.AllDirectories)
+              var files = Directory.GetFiles(path, "*.*", recursive ? SearchOption.AllDirectories : SearchOption.TopDirectoryOnly)
                     .Where(
                         f => allowedFileExtensions == null || allowedFileExtensions.Any(x => f.EndsWith(x, StringComparison.InvariantCultureIgnoreCase)))
                     .ToArray();

--- a/SquishIt.Framework/Resolvers/HttpResolver.cs
+++ b/SquishIt.Framework/Resolvers/HttpResolver.cs
@@ -32,7 +32,7 @@ namespace SquishIt.Framework.Resolvers
             }            
         }
 
-        public IEnumerable<string> TryResolveFolder(string path, IEnumerable<string> allowedExtensions) {
+        public IEnumerable<string> TryResolveFolder(string path, bool recursive, IEnumerable<string> allowedExtensions) {
             throw new NotImplementedException("Adding entire directories only supported by FileSystemResolver.");
         }
 

--- a/SquishIt.Framework/Resolvers/IResolver.cs
+++ b/SquishIt.Framework/Resolvers/IResolver.cs
@@ -6,6 +6,6 @@ namespace SquishIt.Framework.Resolvers
     {
         bool IsDirectory(string path);
         string TryResolve(string path);
-        IEnumerable<string> TryResolveFolder(string path, IEnumerable<string> allowedExtensions);
+        IEnumerable<string> TryResolveFolder(string path, bool recursive, IEnumerable<string> allowedExtensions);
     }
 }

--- a/SquishIt.Tests/CssBundleTests.cs
+++ b/SquishIt.Tests/CssBundleTests.cs
@@ -78,7 +78,8 @@ namespace SquishIt.Tests
                 .WithDebuggingEnabled(true)
                 .Create();
 
-            cssBundle1.Add("/css/first.css", "/css/second.css");
+            // Obsolete Test
+            // cssBundle1.Add("/css/first.css", "/css/second.css");
             cssBundle2.Add("/css/first.css").Add("/css/second.css");
 
             var cssBundle1Assets = cssBundle1.bundleState.Assets;

--- a/SquishIt.Tests/FileSystemResolverTests.cs
+++ b/SquishIt.Tests/FileSystemResolverTests.cs
@@ -70,7 +70,7 @@ namespace SquishIt.Tests
                 File.Create(Path.Combine(directory.FullName, "file1")).Close();
                 File.Create(Path.Combine(directory.FullName, "file2")).Close();
 
-                var result = new FileSystemResolver().TryResolveFolder(path, null).ToList();
+                var result = new FileSystemResolver().TryResolveFolder(path, true, null).ToList();
                 Assert.AreEqual(2, result.Count);
                 Assert.Contains(path + Path.DirectorySeparatorChar + "file1", result);
                 Assert.Contains(path + Path.DirectorySeparatorChar + "file2", result);
@@ -93,7 +93,7 @@ namespace SquishIt.Tests
                 File.Create(Path.Combine(directory.FullName, "file2.css")).Close();
                 File.Create(Path.Combine(directory.FullName, "file21.JS")).Close();
 
-                var result = new FileSystemResolver().TryResolveFolder(path, new[] { ".js" }).ToList();
+                var result = new FileSystemResolver().TryResolveFolder(path, true, new[] { ".js" }).ToList();
                 Assert.AreEqual(2, result.Count);
                 Assert.Contains(path + Path.DirectorySeparatorChar + "file1.js", result);
                 Assert.Contains(path + Path.DirectorySeparatorChar + "file21.JS", result);

--- a/SquishIt.Tests/Stubs/StubResolver.cs
+++ b/SquishIt.Tests/Stubs/StubResolver.cs
@@ -20,7 +20,7 @@ namespace SquishIt.Tests.Stubs
             return _pathToResolveTo;
         }
 
-        public IEnumerable<string> TryResolveFolder(string path, IEnumerable<string> allowedExtensions) {
+        public IEnumerable<string> TryResolveFolder(string path, bool recursive, IEnumerable<string> allowedExtensions) {
             return _directoryContents
                 .Where(dc => allowedExtensions.Any(ext => dc.EndsWith(ext, System.StringComparison.InvariantCultureIgnoreCase)))
                 .ToArray();

--- a/SquishItAspNetTest/Default.aspx
+++ b/SquishItAspNetTest/Default.aspx
@@ -55,7 +55,13 @@
                 .Add("~/css/import.css")
                 .WithAttribute("media", "screen")
                 .ForceRelease()
-                .Render("~/combinedimport_#.css") %>     
+                .Render("~/combinedimport_#.css") %>   
+    <!-- NonRecursive Test -->  
+    <%= Bundle.Css()
+                .AddDirectory("~/css/", true)
+                .WithAttribute("media", "screen")
+                .ForceDebug()
+                .Render("~/nonrecursivedirectory_#.css") %>     
     <form id="form1" runat="server">
     <div>
     


### PR DESCRIPTION
Added support for this call as it's more discoverable and added new feature to support non-recursive (recursive is still default). Did not change behavior of Add().
