### PR TITLE
CSS. Do not modify urls starting with hash

### DIFF
--- a/SquishIt.Framework/Css/CssPathRewriter.cs
+++ b/SquishIt.Framework/Css/CssPathRewriter.cs
@@ -71,7 +71,7 @@ namespace SquishIt.Framework.Css {
             foreach (Match match in matches) 
             {
                 var path = match.Groups[1].Captures[0].Value;
-                if (!path.StartsWith ("/") && !path.StartsWith ("http://") && !path.StartsWith ("https://") && !path.StartsWith ("data:") && !path.StartsWith ("squishit://")) 
+                if (!path.StartsWith("/") && !path.StartsWith("http://") && !path.StartsWith("https://") && !path.StartsWith("data:") && !path.StartsWith("squishit://") && !path.StartsWith("#")) 
                 {
                     if (matchesHash.Add (path)) 
                     {

--- a/SquishIt.Tests/CssPathRewriterTests.cs
+++ b/SquishIt.Tests/CssPathRewriterTests.cs
@@ -392,5 +392,51 @@ namespace SquishIt.Tests
                                                     ";
             Assert.AreEqual(expected, result);
         }
+
+        [Test]
+        public void WontRewriteUrlsStartWithHash()
+        {
+
+
+            ICssAssetsFileHasher cssAssetsFileHasher = null;
+            const string css = @"
+                                                        .header {
+                                                                background: url('#something') no-repeat 0 0;
+                                                        }
+                                                    ";
+            string sourceFile = TestUtilities.PreparePath(@"C:\somepath\somesubpath\myfile.css");
+            string targetFile = TestUtilities.PreparePath(@"C:\somepath\someothersubpath\evendeeper\output.css");
+            string result = CSSPathRewriter.RewriteCssPaths(targetFile, sourceFile, css, cssAssetsFileHasher);
+
+            const string expected = @"
+                                                        .header {
+                                                                background: url('#something') no-repeat 0 0;
+                                                        }
+                                                    ";
+            Assert.AreEqual(expected, result);
+        }
+
+        [Test]
+        public void WontRewriteHashUrls()
+        {
+
+
+            ICssAssetsFileHasher cssAssetsFileHasher = null;
+            const string css = @"
+                                                        .header {
+                                                                background: url('#') no-repeat 0 0;
+                                                        }
+                                                    ";
+            string sourceFile = TestUtilities.PreparePath(@"C:\somepath\somesubpath\myfile.css");
+            string targetFile = TestUtilities.PreparePath(@"C:\somepath\someothersubpath\evendeeper\output.css");
+            string result = CSSPathRewriter.RewriteCssPaths(targetFile, sourceFile, css, cssAssetsFileHasher);
+
+            const string expected = @"
+                                                        .header {
+                                                                background: url('#') no-repeat 0 0;
+                                                        }
+                                                    ";
+            Assert.AreEqual(expected, result);
+        }
     }
 }


### PR DESCRIPTION
Hello all. We use SquishIt in our project.
But it breaks "IE6 hack for fixed posiotion blocks" using url('#').
Here is a fix: do not modify urls starting with hash.

More details:
https://github.com/jetheredge/SquishIt/issues/123#issuecomment-5022877

> Hello all.
> 
> There is an IE6 hack for fixed blocks containing this css code:
> 
> body{
> background: #FFFFFF url('#') fixed;
> }
> 
> So after combination it is converted to:
> body{
> background: #FFFFFF url('css/%23') fixed;
> }
> 
> May be url('#') should stay as url('#') because this is a hack for browser to make no requests (it loads current css file from cache)
