### PR TITLE
Patch for Issue 196

### DIFF
--- a/SquishIt.Framework/Base/BundleState.cs
+++ b/SquishIt.Framework/Base/BundleState.cs
@@ -7,6 +7,8 @@ namespace SquishIt.Framework.Base
     {
         internal List<Asset> Assets = new List<Asset>();
         internal Dictionary<string, string> Attributes = new Dictionary<string, string>();
+        internal HashSet<string> Arbitrary = new HashSet<string>();
+        
         internal int Order { get; set; }
         public bool ForceDebug { get; set; }
         public bool ForceRelease { get; set; }

--- a/SquishIt.Tests/JavaScriptBundleTests.cs
+++ b/SquishIt.Tests/JavaScriptBundleTests.cs
@@ -634,6 +634,24 @@ namespace SquishIt.Tests
         }
 
         [Test]
+        public void CanRenderArbitraryStringsInDebugAsCached()
+        {
+            var content = debugJavaScriptBundle
+                .AddString(javaScript)
+                .Add("~/js/test.js")
+                .AsCached("Test3", "~/js/output_2.js");
+
+            var cachedContent = debugJavaScriptBundle.RenderCached("Test3");
+
+            debugJavaScriptBundle.ClearCache();
+
+            var generatedContent = debugJavaScriptBundle.RenderCached("Test3");
+
+            Assert.AreEqual(cachedContent, content);
+            Assert.AreEqual(cachedContent, generatedContent);
+        }
+
+        [Test]
         public void CanRenderArbitraryStringsInDebugWithoutType () 
         {
             var js2Format = "{0}{1}";


### PR DESCRIPTION
Moved arbitrary string collection from the BundleBase into the BundleState
Added a IRenderer call into the BundleBase.Render method to persist in debug data in a RenderCachedAssetTag call
