### PR TITLE
avoid exception on empty content.

### DIFF
--- a/SquishIt.Framework/Base/BundleBase.Rendering.Internals.cs
+++ b/SquishIt.Framework/Base/BundleBase.Rendering.Internals.cs
@@ -415,7 +415,7 @@ namespace SquishIt.Framework.Base
 
         protected string MinifyIfNeeded(string content, bool minify)
         {
-            if (minify)
+            if (minify && !string.IsNullOrEmpty(content))
             {
                 var minified = Minifier.Minify(content);
                 return AppendFileClosure(minified);


### PR DESCRIPTION
If file exists, but is empty, compression will throw an exception.  No compression needed, move on.
