### PR TITLE
ResolveAppRelativePathToFileSystem can be broken when app isn't in root ...

### DIFF
--- a/SquishIt.Framework/FileSystem.cs
+++ b/SquishIt.Framework/FileSystem.cs
@@ -16,7 +16,7 @@ namespace SquishIt.Framework
 
             return HttpContext.Current == null 
                 ? ProcessWithoutHttpContext(file) 
-                : HttpContext.Current.Server.MapPath(file);
+                : HttpContext.Current.Server.MapPath(HttpContext.Current.Request.ApplicationPath + "/" + file.TrimStart("~/").TrimStart("~"));
         }
 
         static string ProcessWithoutHttpContext(string file)


### PR DESCRIPTION
...folder on server

Fix is required for processing css imports `Bundle.Css().Add(...).ProcessImports()...`
