### PR TITLE
default drive share

### DIFF
--- a/SquishIt.Framework/CSS/RelativePathAdapter.cs
+++ b/SquishIt.Framework/CSS/RelativePathAdapter.cs
@@ -70,7 +70,7 @@ namespace SquishIt.Framework.CSS
             var commonPath = String.Empty;
 
             //Is Network Path Regular Expression
-            const string pattern = @"^\\{2}[\w-]+(\\{1}(([\w-][\w-\s]*[\w-]+[$$]?)|([\w-][$$]?$)))+";
+            const string pattern = @"^\\{2}[\w-]+(\\{1}(([\w-][\w-\s]*[\w-]+[$$]?)|([\w-][$$]?$)|(\w\$)))+";
 
             if (System.Text.RegularExpressions.Regex.IsMatch(shortest, pattern))
             {

--- a/SquishIt.Tests/RelativePathAdapterTest.cs
+++ b/SquishIt.Tests/RelativePathAdapterTest.cs
@@ -28,5 +28,18 @@ namespace SquishIt.Tests
 
             Assert.IsNotNull(adapter);
         }
+
+        [Test]
+        public void DoesNotErrorOnDefaultDriveShare()
+        {
+            //variant of share path that is a default drive share (e.g. \\server\d$\style.css)
+            var from = @"\\network\d$\website\assets\css\main\";
+            var to = @"\\network\d$\website\Content\style.css";
+
+            var adapter = RelativePathAdapter.Between(from, to);
+
+            Assert.IsNotNull(adapter);
+        }
+
     }
 }


### PR DESCRIPTION
Found a  problem in the regex in our dev environment.  Had a share with the pattern \server\d$\site\file.css and the regex couldn't handle the d$.

Added an additional "or" to match on a word (\w) followed by a $  
