### PR TITLE
Remove and re-add the NSass project, update MVC Tests project to be VS20...

### DIFF
--- a/SquishIt.Tests/SquishIt.Tests.csproj
+++ b/SquishIt.Tests/SquishIt.Tests.csproj
@@ -160,7 +160,7 @@
       <Name>SquishIt.MsIeHogan</Name>
     </ProjectReference>
     <ProjectReference Include="..\SquishIt.NSass\SquishIt.NSass.csproj">
-      <Project>{8D1EE11A-C71D-453D-B0BC-0A76C20B010E}</Project>
+      <Project>{8d1ee11a-c71d-453d-b0bc-0a76c20b010e}</Project>
       <Name>SquishIt.NSass</Name>
     </ProjectReference>
     <ProjectReference Include="..\SquishIt.Sass\SquishIt.Sass.csproj">

--- a/SquishItAspNetMvcTest/SquishItAspNetMvcTest.csproj
+++ b/SquishItAspNetMvcTest/SquishItAspNetMvcTest.csproj
@@ -1,5 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="4.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
   <PropertyGroup>
     <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
     <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
@@ -19,6 +20,11 @@
     <IISExpressAnonymousAuthentication />
     <IISExpressWindowsAuthentication />
     <IISExpressUseClassicPipelineMode />
+    <MvcProjectUpgradeChecked>true</MvcProjectUpgradeChecked>
+    <FileUpgradeFlags>
+    </FileUpgradeFlags>
+    <OldToolsVersion>4.0</OldToolsVersion>
+    <UpgradeBackupLocation />
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
     <DebugSymbols>true</DebugSymbols>
@@ -202,8 +208,13 @@
   <ItemGroup>
     <Folder Include="output\" />
   </ItemGroup>
+  <PropertyGroup>
+    <VisualStudioVersion Condition="'$(VisualStudioVersion)' == ''">10.0</VisualStudioVersion>
+    <VSToolsPath Condition="'$(VSToolsPath)' == ''">$(MSBuildExtensionsPath32)\Microsoft\VisualStudio\v$(VisualStudioVersion)</VSToolsPath>
+  </PropertyGroup>
   <Import Project="$(MSBuildBinPath)\Microsoft.CSharp.targets" />
-  <Import Project="$(MSBuildExtensionsPath32)\Microsoft\VisualStudio\v10.0\WebApplications\Microsoft.WebApplication.targets" />
+  <Import Project="$(VSToolsPath)\WebApplications\Microsoft.WebApplication.targets" Condition="'$(VSToolsPath)' != ''" />
+  <Import Project="$(MSBuildExtensionsPath32)\Microsoft\VisualStudio\v10.0\WebApplications\Microsoft.WebApplication.targets" Condition="false" />
   <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 
        Other similar extension points exist, see Microsoft.Common.targets.
   <Target Name="BeforeBuild">


### PR DESCRIPTION
...13-compatible.

The aim of this PR is to try to fix the broken build, which has the following error:

```
System.IO.FileNotFoundException : Could not load file or assembly 'NSass.Wrapper.x64.dll' or one of its dependencies. The specified module could not be found.
   at NSass.SassCompiler..ctor()
```

I couldn't reproduce the error on my machine by deleting the NSassWrapper folder from the output directory.  When I did, I got this error, which is pretty different:

```
The type initializer for 'NSass.SassCompiler' threw an exception.
  ----> System.InvalidOperationException : Found NSass.Wrapper.proxy.dll which cannot exist. Must instead have NSass.Wrapper.x86.dll and NSass.Wrapper.x64.dll. Check your build settings.C:\Users\jkodroff.INTERNAL.000\Code\SquishIt\SquishIt.Tests\bin\Debug\NSass.Wrapper
    at NSass.SassCompiler..ctor()
```

It may be totally unrelated, but I noticed that the tests would not build in Release mode, so I removed and re-added the reference and they did build in release mode.

In opening the solution, I also automatically updated the MVC project so that it's VS2013-compatible.  (Couldn't be helped - I only have 2013 installed.)
