### PR TITLE
Fixed PathTooLong error when Base64 data images are included alongside r...

### DIFF
--- a/SquishIt.Framework/CSS/CSSPathRewriter.cs
+++ b/SquishIt.Framework/CSS/CSSPathRewriter.cs
@@ -93,9 +93,10 @@ namespace SquishIt.Framework.CSS
         {
             var matches = pathsRegex.Matches(css);
             return matches.Cast<Match>()
-                .Select(match => match.Groups[1].Captures[0].Value)
-                .Where(path => !path.StartsWith("http", StringComparison.InvariantCultureIgnoreCase))
-                .Distinct();
+                          .Select(match => match.Groups[1].Captures[0].Value)
+                          .Where(path => !path.StartsWith("http", StringComparison.InvariantCultureIgnoreCase)
+                                      && !path.StartsWith("data:"))
+                          .Distinct();
         }
     }
 }


### PR DESCRIPTION
...elative image URLs

Ran into issues with Windows throwing exceptions for small path sizes. Found out Base64 images were being parsed for FileSystemResolver. Check it out and let me know if it's cool. Tempted to have the designer pull all the base64 images out, but there appears to be a lot of them, hence bug fix. 

Thanks!
