### PR TITLE
Wildcards and Ignores

### DIFF
--- a/SquishIt.Framework/Base/BundleBase.cs
+++ b/SquishIt.Framework/Base/BundleBase.cs
@@ -142,6 +142,16 @@ namespace SquishIt.Framework.Base
             return (T)this;
         }
 
+		/// <summary>
+		/// Ignore certain types of files from the list of located files
+		/// </summary>
+		/// <param name="filePattern">Pattern to match for ignored files (eg: *.test.js)</param>
+		public T Ignore(string filePattern)
+		{
+			bundleState.Ignore.Add(filePattern);
+			return (T)this;
+		}
+
         /// <summary>
         /// Add arbitrary content that is not saved on disk.
         /// </summary>

--- a/SquishIt.Framework/Base/BundleState.cs
+++ b/SquishIt.Framework/Base/BundleState.cs
@@ -25,15 +25,19 @@ namespace SquishIt.Framework.Base
         internal bool ForceRelease { get; set; }
         internal string Path { get; set; }
 
+		internal List<string> Ignore { get; set; }
+
         internal IRenderer ReleaseFileRenderer { get; set; }
         internal ICacheInvalidationStrategy CacheInvalidationStrategy { get; set; }
         internal Func<bool> DebugPredicate { get; set; }
 
         internal BundleState()
-        { 
+        {
+			Ignore = new List<string>();
         }
 
         internal BundleState(Dictionary<string, string> attributes)
+			: this()
         {
             Attributes = attributes;
         }

--- a/SquishIt.Framework/Resolvers/FileSystemResolver.cs
+++ b/SquishIt.Framework/Resolvers/FileSystemResolver.cs
@@ -5,45 +5,63 @@ using System.Linq;
 
 namespace SquishIt.Framework.Resolvers
 {
-    public class FileSystemResolver : IResolver
-    {
-        public string Resolve(string file) 
-        {
-            return Path.GetFullPath(file);
-        }
+	public class FileSystemResolver : IResolver
+	{
+		public string Resolve(string file)
+		{
+			return Path.GetFullPath(file);
+		}
 
-        public bool IsDirectory(string path) 
-        {
-            return Directory.Exists(path);
-        }
+		public bool IsDirectory(string path)
+		{
+			return Directory.Exists(path) || HasSearchPath(path);
+		}
 
-        public IEnumerable<string> ResolveFolder(string path, bool recursive, string debugFileExtension, IEnumerable<string> allowedFileExtensions, IEnumerable<string> disallowedFileExtensions)
-        {
-            if (IsDirectory(path)) 
-            {
-              var files = Directory.GetFiles(path, "*.*", recursive ? SearchOption.AllDirectories : SearchOption.TopDirectoryOnly)
-                    .Where(
-                        file =>
-                        {
-                            var f = file.ToUpperInvariant();
-                            return !f.EndsWith(debugFileExtension.ToUpperInvariant()) &&
-                                   (allowedFileExtensions == null ||
-                                    allowedFileExtensions.Select(s => s.ToUpper()).Any(f.EndsWith) &&
-                                    (disallowedFileExtensions == null ||
-                                     !disallowedFileExtensions.Select(s => s.ToUpper()).Any(f.EndsWith)));
-                        })
-                    .ToArray();
-                Array.Sort(files);
-                return files;
-            }
-            return new[] { Path.GetFullPath(path) };
-        }
+		bool HasSearchPath(string path)
+		{
+			var filename = Path.GetFileName(path);
+			return filename.Contains("*") || filename.Contains("?");
+		}
 
-        static IEnumerable<string> Extensions(string path)
-        {
-            return path.Split('.')
-                .Skip(1)
-                .Select(s => "." + s.ToUpperInvariant());
-        }
-    }
+		string GetSearchPath(string path)
+		{
+			return Path.GetFileName(path);
+		}
+
+		public IEnumerable<string> ResolveFolder(string path, bool recursive, string debugFileExtension, IEnumerable<string> allowedFileExtensions, IEnumerable<string> disallowedFileExtensions)
+		{
+			if (IsDirectory(path))
+			{
+				var searchPath = "*.*";
+				if(HasSearchPath(path))
+				{
+					searchPath = GetSearchPath(path);
+					path = Path.GetDirectoryName(path);
+				}
+
+				var files = Directory.GetFiles(path, searchPath, recursive ? SearchOption.AllDirectories : SearchOption.TopDirectoryOnly)
+					  .Where(
+						  file =>
+						  {
+							  var f = file.ToUpperInvariant();
+							  return !f.EndsWith(debugFileExtension.ToUpperInvariant()) &&
+									 (allowedFileExtensions == null ||
+									  allowedFileExtensions.Select(s => s.ToUpper()).Any(f.EndsWith) &&
+									  (disallowedFileExtensions == null ||
+									   !disallowedFileExtensions.Select(s => s.ToUpper()).Any(f.EndsWith)));
+						  })
+					  .ToArray();
+				Array.Sort(files);
+				return files;
+			}
+			return new[] { Path.GetFullPath(path) };
+		}
+
+		static IEnumerable<string> Extensions(string path)
+		{
+			return path.Split('.')
+				.Skip(1)
+				.Select(s => "." + s.ToUpperInvariant());
+		}
+	}
 }

--- a/SquishIt.Tests/FileSystemResolverTests.cs
+++ b/SquishIt.Tests/FileSystemResolverTests.cs
@@ -104,6 +104,30 @@ namespace SquishIt.Tests
             }
         }
 
+		[Test]
+		public void CanResolveDirectory_Filters_Files_By_Wildcard()
+		{
+			var path = Guid.NewGuid().ToString();
+			var directory = Directory.CreateDirectory(path);
+
+			var searchPath = Path.Combine(path, "*file2*");
+
+			try
+			{
+				File.Create(Path.Combine(directory.FullName, "file1.js")).Close();
+				File.Create(Path.Combine(directory.FullName, "file2.css")).Close();
+				File.Create(Path.Combine(directory.FullName, "file21.JS")).Close();
+
+				var result = new FileSystemResolver().ResolveFolder(searchPath, true, Guid.NewGuid().ToString(), new[] { ".js" }, new[] { ".css" }).ToList();
+				Assert.AreEqual(1, result.Count);
+				Assert.Contains(path + Path.DirectorySeparatorChar + "file21.JS", result);
+			}
+			finally
+			{
+				Directory.Delete(path, true);
+			}
+		}
+
         [Test]
         public void CanResolveDirectory_Excludes_Debug_Files()
         {

--- a/SquishIt.Tests/SquishIt.Tests.csproj
+++ b/SquishIt.Tests/SquishIt.Tests.csproj
@@ -186,6 +186,9 @@
       <LogicalName>RootEmbedded.js</LogicalName>
     </EmbeddedResource>
   </ItemGroup>
+  <ItemGroup>
+    <Service Include="{82A7F48D-3B50-4B1E-B82E-3ADA8210C358}" />
+  </ItemGroup>
   <Import Project="$(MSBuildBinPath)\Microsoft.CSharp.targets" />
   <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 
        Other similar extension points exist, see Microsoft.Common.targets.


### PR DESCRIPTION
Added the ability to use wildcards in .AddDirectory(), eg:

``` C#
.AddDirectory("/scripts/jquery.*.js") // add whatever version of jquery
.AddDirectory("/scripts/*.min.js") // add pre-minified versions of scripts
```

Added the ability to ignore certain files based on wildcards, eg:

``` C#
.AddDirectory("/application", true)
.Ignore("*.spec.js")
.Ignore("*.test.js") // add all js files in /application except for test/spec files
```
