### PR TITLE
added link to NuGet package and current version badge

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -6,7 +6,11 @@ For medium trust environments there is an option to build and cache bundles in-m
 
 ##Installation
 
-You can download precompiled binaries from the [SquishIt AppHarbor page](http://squishit.apphb.com/Download).
+SquishIt comes as a NuGet package and can be installed via `PM> Install-Package SquishIt`.
+
+Latest stable package: [!(https://img.shields.io/nuget/v/SquishIt.svg)](https://www.nuget.org/packages/SquishIt).
+
+You can also download precompiled binaries from the [SquishIt AppHarbor page](http://squishit.apphb.com/Download).
 
 ### Building from source
 You will need to have Visual Studio and [7-Zip](http://www.7-zip.org/) installed.

--- a/README.markdown
+++ b/README.markdown
@@ -8,7 +8,7 @@ For medium trust environments there is an option to build and cache bundles in-m
 
 SquishIt comes as a NuGet package and can be installed via `PM> Install-Package SquishIt`.
 
-Latest stable package: [!(https://img.shields.io/nuget/v/SquishIt.svg)](https://www.nuget.org/packages/SquishIt).
+Latest stable package: [![nuget version](https://img.shields.io/nuget/v/SquishIt.svg)](https://www.nuget.org/packages/SquishIt).
 
 You can also download precompiled binaries from the [SquishIt AppHarbor page](http://squishit.apphb.com/Download).
 


### PR DESCRIPTION
I think it would be valuable to link to the NuGet package directly from the project's root.