### PR TITLE
fix markdown titles

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -1,10 +1,10 @@
-##About SquishIt
+## About SquishIt
 
 SquishIt is an asset optimization library for .net web applications.  It handles combining and minifying css and javascript assets through creation of bundles.  There are currently extensions available that allow use of .less, coffeescript, SASS/SCSS and Hogan templates through SquishIt's preprocessor pipeline.  There is also an extension that writes your combined files to [Amazon S3](https://github.com/AlexCuse/SquishIt.S3) that can serve as a template for integrating with the CDN of your choosing.
 
 For medium trust environments there is an option to build and cache bundles in-memory so that you don't need write permission in the application's working directory.  An example of setting this up for an ASP.net MVC project can be found [here](https://github.com/jetheredge/SquishIt/wiki/Using-SquishIt-programmatically-without-the-file-system).  For a WebForms project the asset controller would just be replaced with an HTTP handler.
 
-##Installation
+## Installation
 
 SquishIt comes as a NuGet package and can be installed via `PM> Install-Package SquishIt`.
 
@@ -22,7 +22,7 @@ You will need to have Visual Studio and [7-Zip](http://www.7-zip.org/) installed
 
 If all went well, you should have a package called <code>tools/SquishIt-<var>version-id</var>.zip</code>.
 
-##Thanks
+## Thanks
 
 The build is generously hosted and run on the [CodeBetter TeamCity](http://codebetter.com/codebetter-ci/) infrastructure.
 


### PR DESCRIPTION
Hello,

There were some missing ` ` between `#` and titles. This PR fix those.

Cheers,